### PR TITLE
Net messages don't support more than 32-bits silly

### DIFF
--- a/gamemodes/jazztronauts/gamemode/map/mapcontrol.lua
+++ b/gamemodes/jazztronauts/gamemode/map/mapcontrol.lua
@@ -157,7 +157,7 @@ if SERVER then
 
 		net.Start("jazz_rollmap")
 			net.WriteString(curSelected.map)
-			net.WriteUInt(curSelected.wsid, 64)
+			net.WriteString(curSelected.wsid)
 			net.WriteUInt(#curSelected.maps, 8)
 			for _, v in ipairs(curSelected.maps) do
 				net.WriteString(v)
@@ -371,7 +371,7 @@ else //CLIENT
 
 	net.Receive("jazz_rollmap", function(len, ply)
 		curSelected = net.ReadString()
-		local wsid = net.ReadUInt(64)
+		local wsid = tonumber(net.ReadString())
 		local maps = { curSelected }
 
 		-- Read list of maps that are a part of this map pack


### PR DESCRIPTION
Fixes behavior on GMod's x86-64 branch, where attempting to network more than 32-bits results in integer overflow, instead of the offending net.ReadUInt simply returning 0 (as was old behavior, to "indicate" an error).

Integer overflow also had the adverse affect of making `num` a potentially huge number, creating a `table overflow` error, after GMod stops hanging from trying to fill the `maps` table with like a million entries of garbage.