### PR TITLE
Undo DLib check for Remove()

### DIFF
--- a/gamemodes/jazztronauts/entities/entities/jazz_hub_propvomiter/cl_init.lua
+++ b/gamemodes/jazztronauts/entities/entities/jazz_hub_propvomiter/cl_init.lua
@@ -12,12 +12,7 @@ local function TickVomitProps()
 		if not IsValid(p) or t < 0 then
 			table.remove(JazzVomitProps, i)
 			if IsValid(p) then
-				if DLib then
-					-- Bypass DLib's 'Remove' override
-					p:RemoveDLib()
-				else
-					p:Remove()
-				end
+				p:Remove()
 			end
 			continue
 		end


### PR DESCRIPTION
DLib nolonger overrides ENTITY:Remove(),
https://gitlab.com/DBotThePony/DLib/commit/fb822e0795aa8326b1f72197afb438a133f7090a