### PR TITLE
Add a gamemode category

### DIFF
--- a/gamemodes/jazztronauts/jazztronauts.txt
+++ b/gamemodes/jazztronauts/jazztronauts.txt
@@ -4,6 +4,7 @@
 	"title"			"Jazztronauts"
 	"menusystem" 	"1"
 	"maps" 			"jazz_bar"
+	"category"		"pve"
 	"workshopid"	"1452613192"
 
 	"settings"


### PR DESCRIPTION
This is a new thing from the [Garry's Mod March 2021 update](https://store.steampowered.com/news/app/4000/view/2988675197234811880).

Info about the categories values here: https://wiki.facepunch.com/gmod/Gamemode_Creation#category

I choose "pve" as it can make sense but if you think another category would be more appropriate, I'll let you decide...