### PR TITLE
mapgen.CalculateShardCount: Calculate area of the map properly

### DIFF
--- a/gamemodes/jazztronauts/gamemode/map/mapgen.lua
+++ b/gamemodes/jazztronauts/gamemode/map/mapgen.lua
@@ -414,7 +414,7 @@ if SERVER then
 		local area = math.clamp(math.abs(maxs.x - mins.x) * math.abs(maxs.y - mins.y), 8000, 100000)
 		print(area)
 		-- Shard count dependent on map size
-		local shardcount = math.max(1, math.Remap(area, 8000, 100000, 4, 24))
+		local shardcount = math.Remap(area, 8000, 100000, 4, 24)
 		return math.ceil(shardcount)
 	end
 

--- a/gamemodes/jazztronauts/gamemode/map/mapgen.lua
+++ b/gamemodes/jazztronauts/gamemode/map/mapgen.lua
@@ -411,7 +411,7 @@ if SERVER then
 		local maxs, mins = Vector(winfo.world_maxs), Vector(winfo.world_mins)
 
 		-- Calculate only area, ignoring Z because people make bigass fucking skyboxes
-		local area = math.clamp(math.abs(maxs.x - mins.x) * math.abs(maxs.y - mins.y), 8000, 100000)
+		local area = math.Clamp(math.abs(maxs.x - mins.x) * math.abs(maxs.y - mins.y), 8000, 100000)
 		print(area)
 		-- Shard count dependent on map size
 		local shardcount = math.Remap(area, 8000, 100000, 4, 24)

--- a/gamemodes/jazztronauts/gamemode/map/mapgen.lua
+++ b/gamemodes/jazztronauts/gamemode/map/mapgen.lua
@@ -411,7 +411,7 @@ if SERVER then
 		local maxs, mins = Vector(winfo.world_maxs), Vector(winfo.world_mins)
 
 		-- Calculate only area, ignoring Z because people make bigass fucking skyboxes
-		local area = math.sqrt(math.pow(maxs.x - mins.x, 2) + math.pow(maxs.y - mins.y, 2))
+		local area = math.clamp(math.abs(maxs.x - mins.x) * math.abs(maxs.y - mins.y), 8000, 100000)
 		print(area)
 		-- Shard count dependent on map size
 		local shardcount = math.max(1, math.Remap(area, 8000, 100000, 4, 24))


### PR DESCRIPTION
I recently decided to look at the code for spawning Shards and discovered a bug that's been lying in plain sight since Commit https://github.com/Foohy/jazztronauts/commit/2894e6e4026ad5b9a446381ddb7d319a0667f1b8 from 2018.
The area for a rectangle is width times height, but it was improperly calculated as width plus height. As a result, the area variable would be significantly less than the actual area of the map. The code defined the maximum number of Shards for a map as 24, but it was actually 13 in practice due to this miscalculation. If we assume a map is loaded that has the dimensions of 32768x32768 Hammer Units, which is the maximum that can fit within the Hammer Grid, the old code would return a value of 46,340 Hammer Units for its area. This would result in a calculated shardcount of 12.33 Shards, which is then rounded to 13 Shards. However, the map's actual area is 1,073,709,056 Hammer Units and it should get the maximum shardcount of 24 Shards.

I found a second latent bug that needed to be fixed as well, as giving math.Remap a value outside of the input range results in undefined behavior. Maps with areas smaller than 8,000 would spawn 2 or 3 Shards, instead of the defined 4 Shard minimum, and maps with areas bigger than 100,000 could spawn more than 24 Shards. For example, that maximum-sized map would attempt to spawn 233,417 Shards. I fixed this by clamping the returned area so that it would always fall within the expected range.

I additionally did some code cleanup:
by removing a redundant call to math.max, as it would always return the number from math.Remap.
by making the negative number handling in the area calculation use math.abs to get the positive absolute value instead of squaring and then square-rooting the numbers. 