### PR TITLE
Implement unused idle dialogue for before and after the true ending.

### DIFF
--- a/gamemodes/jazztronauts/content/data/scripts_en/idle.txt
+++ b/gamemodes/jazztronauts/content/data/scripts_en/idle.txt
@@ -8,42 +8,30 @@ begin:
 begin1:
     *setauto 0*
     condition:
-     &bar_bark1:
-          return not state("ended")
-          return maybe(6, 1)
-     &bar_bark2:
-          return not state("ended")
-          return maybe(6, 2)
-     &bar_bark3:
-          return not state("ended")
-          return maybe(6, 3)
-     &bar_bark4:
-          return not state("ended")
-          return maybe(6, 4)
-     &bar_bark5:
-          return not state("ended")
-          return maybe(6, 5)
-     &bar_bark6:
-          return state("ending") == 2
-          return maybe(6, 6)
-     &bar_truebark1:
-          return state("ending") == 2
-          return maybe(6, 1)
-     &bar_truebark2:
-          return state("ending") == 2
-          return maybe(6, 2)
-     &bar_truebark3:
-          rreturn state("ending") == 2
-          return maybe(6, 3)
-     &bar_truebark4:
-          return state("ending") == 2
-          return maybe(6, 4)
-     &bar_truebark5:
-          return state("ending") == 2
-          return maybe(6, 5)
-     &bar_truebark6:
-          return state("ending") == 2
-          return maybe(6, 6)
+          &bar_bark1:
+               return not state("ended") and maybe(6, 1)
+          &bar_bark2:
+               return not state("ended") and maybe(6, 2)
+          &bar_bark3:
+               return not state("ended") and maybe(6, 3)
+          &bar_bark4:
+               return not state("ended") and maybe(6, 4)
+          &bar_bark5:
+               return not state("ended") and maybe(6, 5)
+          &bar_bark6:
+               return not state("ended") and maybe(6, 6)
+          &bar_truebark1:
+               return state("ending") == 2 and maybe(6, 1)
+          &bar_truebark2:
+               return state("ending") == 2 and maybe(6, 2)
+          &bar_truebark3:
+               return state("ending") == 2 and maybe(6, 3)
+          &bar_truebark4:
+               return state("ending") == 2 and maybe(6, 4)
+          &bar_truebark5:
+               return state("ending") == 2 and maybe(6, 5)
+          &bar_truebark6:
+               return state("ending") == 2 and maybe(6, 6)
 
 begin4:
      *setauto 0*

--- a/gamemodes/jazztronauts/content/data/scripts_en/idle.txt
+++ b/gamemodes/jazztronauts/content/data/scripts_en/idle.txt
@@ -8,21 +8,52 @@ begin:
 begin1:
     *setauto 0*
     condition:
-    &itsthattime:
-        local d \= date("\*t")
-        return d.hour \=\=4 and d.min \=\= 20
-	&bar_bark1:
-        return maybe(6, 1)
-	&bar_bark2:
-        return maybe(6, 2)
-    &bar_bark3:
-        return maybe(6, 3)
-    &bar_bark4:
-        return maybe(6, 4)
-    &bar_bark5:
-        return maybe(6, 5)
-    &bar_bark6:
-        return maybe(6, 6)
+     &bar_bark1:
+          return not state("ended")
+          return maybe(6, 1)
+     &bar_bark2:
+          return not state("ended")
+          return maybe(6, 2)
+     &bar_bark3:
+          return not state("ended")
+          return maybe(6, 3)
+     &bar_bark4:
+          return not state("ended")
+          return maybe(6, 4)
+     &bar_bark5:
+          return not state("ended")
+          return maybe(6, 5)
+     &bar_bark6:
+          return state("ending") == 2
+          return maybe(6, 6)
+     &bar_truebark1:
+          return state("ending") == 2
+          return maybe(6, 1)
+     &bar_truebark2:
+          return state("ending") == 2
+          return maybe(6, 2)
+     &bar_truebark3:
+          rreturn state("ending") == 2
+          return maybe(6, 3)
+     &bar_truebark4:
+          return state("ending") == 2
+          return maybe(6, 4)
+     &bar_truebark5:
+          return state("ending") == 2
+          return maybe(6, 5)
+     &bar_truebark6:
+          return state("ending") == 2
+          return maybe(6, 6)
+
+begin4:
+     *setauto 0*
+     condition:
+          &itsthattime:
+          local d \= date("\*t")
+          return d.hour \=\=4 and d.min \=\= 20
+     
+     thanks for doing my grocery shopping
+     &exit
 
 bar_bark1:
     *setauto*
@@ -331,10 +362,6 @@ begin12:
     *slam FUCK.* *emitsound npc/metropolice/gear3.wav*% BAIL.
     *emitsound npc/metropolice/takedown.wav*"ＴＡＫＥ ＨＩＭ ＤＯＷＮ" *punch**emitsound npc/vort/foot_hit.wav**fadeblind**dsp 37*
     *setskin focus 0*
-    &exit
-
-begin4:
-    thanks for doing my grocery shopping
     &exit
 
 begin32:

--- a/gamemodes/jazztronauts/content/data/scripts_en/idle.txt
+++ b/gamemodes/jazztronauts/content/data/scripts_en/idle.txt
@@ -8,40 +8,173 @@ begin:
 begin1:
     *setauto 0*
     condition:
-          &bar_bark1:
-               return not state("ended") and maybe(6, 1)
-          &bar_bark2:
-               return not state("ended") and maybe(6, 2)
-          &bar_bark3:
-               return not state("ended") and maybe(6, 3)
-          &bar_bark4:
-               return not state("ended") and maybe(6, 4)
-          &bar_bark5:
-               return not state("ended") and maybe(6, 5)
-          &bar_bark6:
-               return not state("ended") and maybe(6, 6)
-          &bar_truebark1:
-               return state("ending") == 2 and maybe(6, 1)
-          &bar_truebark2:
-               return state("ending") == 2 and maybe(6, 2)
-          &bar_truebark3:
-               return state("ending") == 2 and maybe(6, 3)
-          &bar_truebark4:
-               return state("ending") == 2 and maybe(6, 4)
-          &bar_truebark5:
-               return state("ending") == 2 and maybe(6, 5)
-          &bar_truebark6:
-               return state("ending") == 2 and maybe(6, 6)
+    &bar_trueending:
+        local s \= state("ending")
+        return s \=\="2"
+    &bar_normal:
+        return true
+
+bar_normal:
+    *setauto 0*
+    condition:
+    &bar_bark1:
+        return maybe(6, 1)
+    &bar_bark2:
+        return maybe(6, 2)
+    &bar_bark3:
+        return maybe(6, 3)
+    &bar_bark4:
+        return maybe(6, 4)
+    &bar_bark5:
+        return maybe(6, 5)
+    &bar_bark6:
+        return maybe(6, 6)
+
+bar_trueending:
+    *setauto 0*
+    condition:
+    &bar_truebark1:
+        return maybe(6, 1)
+    &bar_truebark2:
+        return maybe(6, 2)
+    &bar_truebark3:
+        return maybe(6, 3)
+    &bar_truebark4:
+        return maybe(6, 4)
+    &bar_truebark5:
+        return maybe(6, 5)
+    &bar_truebark6:
+        return maybe(6, 6)
+
+begin2:
+    *setauto 0*
+    condition:
+    &singer_trueending:
+        local s \= state("ending")
+        return s \=\="2"
+    &singer_normal:
+        return true
+
+singer_normal:
+    *setauto 0*
+    condition:
+    &singer_bark1:
+        return maybe(6, 1)
+    &singer_bark2:
+        return maybe(6, 2)
+    &singer_bark3:
+        return maybe(6, 3)
+    &singer_bark4:
+        return maybe(6, 4)
+    &singer_bark5:
+        return maybe(6, 5)
+    &singer_bark6:
+        return maybe(6, 6)
+
+singer_trueending:
+    *setauto 0*
+    condition:
+    &singer_truebark1:
+        return maybe(6, 1)
+    &singer_truebark2:
+        return maybe(6, 2)
+    &singer_truebark3:
+        return maybe(6, 3)
+    &singer_truebark4:
+        return maybe(6, 4)
+    &singer_truebark5:
+        return maybe(6, 5)
+    &singer_truebark6:
+        return maybe(6, 6)
+
+begin3:
+    *setauto 0*
+    condition:
+    &piano_trueending:
+        local s \= state("ending")
+        return s \=\="2"
+    &piano_normal:
+        return true
+
+piano_normal:
+    *setauto 0*
+    condition:
+    &piano_bark1:
+        return maybe(6, 1)
+    &piano_bark2:
+        return maybe(6, 2)
+    &piano_bark3:
+        return maybe(6, 3)
+    &piano_bark4:
+        return maybe(6, 4)
+    &piano_bark5:
+        return maybe(6, 5)
+    &piano_bark6:
+        return maybe(6, 6)
+
+piano_trueending:
+    *setauto 0*
+    condition:
+    &piano_truebark1:
+        return maybe(6, 1)
+    &piano_truebark2:
+        return maybe(6, 2)
+    &piano_truebark3:
+        return maybe(6, 3)
+    &piano_truebark4:
+        return maybe(6, 4)
+    &piano_truebark5:
+        return maybe(6, 5)
+    &piano_truebark6:
+        return maybe(6, 6)
 
 begin4:
-     *setauto 0*
-     condition:
-          &itsthattime:
-          local d \= date("\*t")
-          return d.hour \=\=4 and d.min \=\= 20
-     
-     thanks for doing my grocery shopping
-     &exit
+    *setauto 0*
+    condition:
+    &itsthattime:
+        local d \= date("\*t")
+        return d.hour \=\=4 and d.min \=\= 20
+    &cello_trueending:
+        local s \= state("ending")
+        return s \=\="2"
+    &cello_normal:
+        return true
+
+cello_normal:
+    *setauto 0*
+    condition:
+    &cello_bark1:
+        return maybe(7, 1)
+    &cello_bark2:
+        return maybe(7, 2)
+    &cello_bark3:
+        return maybe(7, 3)
+    &cello_bark4:
+        return maybe(7, 4)
+    &cello_bark5:
+        return maybe(7, 5)
+    &cello_bark6:
+        return maybe(7, 6)
+    &cello_bark7:
+        return maybe(7, 7)
+
+cello_trueending:
+    *setauto 0*
+    condition:
+    &cello_truebark1:
+        return maybe(7, 1)
+    &cello_truebark2:
+        return maybe(7, 2)
+    &cello_truebark3:
+        return maybe(7, 3)
+    &cello_truebark4:
+        return maybe(7, 4)
+    &cello_truebark5:
+        return maybe(7, 5)
+    &cello_truebark6:
+        return maybe(7, 6)
+    &begin12:
+        return maybe(7, 7)
 
 bar_bark1:
     *setauto*
@@ -83,183 +216,222 @@ piano_bark1:
 
      Hey. Did you enjoy the festival? We don’t often bring guests 
      along, the Band seemed pretty happy to see a new face. 
+     &exit
 
 piano_bark2:
 
      Don’t tell him I said this, but The Cellist has been less of a pain 
      in the ass recently. Don’t know what you did, but thanks. 
+     &exit
 
 piano_bark3:
 
      Pipes’s been smiling a lot more. It’s nice.
+     &exit
 
 piano_bark4:
      Ugh. Why did I agree to help out at the Mewseum, these paws are made 
      for carnage, not data entry.
+     &exit
 
 piano_bark5:
      You know, the Boss likes you. She only brings out the snickerdoodles 
      for special guests.
+     &exit
 
 piano_bark6:
      Make sure you visit, yeah? Gonna miss you. 
+     &exit
 
 singer_bark1:
      >You find The Singer hard at work on that bootleg plant cloning
      program you helped them with. They've been having quite a lot of 
      success, and they're quite proud of their latest bunch of Mr. 
      Stripeys. They weren't kidding when they said tomato names got weird.
+     &exit
 
 singer_bark2:
      > You get a wave when you head over, and The Singer thanks you for 
      helping The Pianist. She’s been smiling a lot more lately, it’s nice.
+     &exit
 
 singer_bark3:
      > You find The Singer sitting with The Cellist. They both appear 
      to be...meditating? You sit with them both for a while.
+     &exit
 
 singer_bark4:
      > The Singer smiles but seems a little sad. They confess that 
      they’re going to miss you very much when you leave.
+     &exit
 
 singer_bark5:
      > The Singer brightens when you approach! You spend a while reading 
      their report on the progress of the Mewseum's residents. 
+     &exit
 
 singer_bark6:
      > The Singer is sitting watching The Bartender with starry eyes, as 
      the other cat plays them a sweet tune on her trumpet. You leave them
      to it. 
+     &exit
 
 cello_bark1:
      you know for how much people talk up pufferfish toxin i think they're
      just cowards. i love to take bites out of them like apples and look 
      at me, i'm the picture of health
+     &exit
 
 cello_bark2:
      i really need to talk to pipes one of these days about getting more 
      proper literature in the library. a man can only read so many prima 
      strategy guides before he longs for some good ol' william burroughs 
      y'know
+     &exit
 
 cello_bark3:
      one of these days i'm going to find out where The Bartender locked
      up all the absinthe. i don't even particularly want to drink it, 
      it doesn't even make you hallucinate a little bit, but it's a matter
      of pride at this point
+     &exit
 
 cello_bark4:
      you seen The Pianist lately? i realize i've been kind of a bastard
      lately and i've been meaning to apologize but i think she's still mad
      about the time i tried to set up a cane toad breeding program. little
      bastards didn't even give a high worth the heart attack
+     &exit
 
 cello_bark5:
      people keep bitching about the fact that they don't have flying cars
      yet. i'm over here wondering why in the hell we don't have robots 
      that recite "there will come soft rains" as they do your household 
      chores just to fuck with you
+     &exit
      
 cello_bark6:
      sometimes i wonder about that one old poet who wondered if he was a
      butterfly dreaming about being a man or a man dreaming about being
      a butterfly, and if i'm in that kind of situation man i want to know
      what kind of butterfly got fucked in the head enough to think of me
+     &exit
+
+cello_bark7:
+    thanks for doing my grocery shopping
+    &exit
 
 
 bar_truebark1:
-     Ah, always a pleasure to see you, <playername>. 
+     Ah, always a pleasure to see you, *player*. 
      The Bar Samsara isn’t the same without you.
+     &exit
 
 bar_truebark2:
      The Pianist and The Cellist have been getting along better than 
      I ever dreamed, as of late. Thank you again for the role you 
      played in their reconciliation. 
+     &exit
 
 bar_truebark3:
      The Singer was telling me that you helped fix Emily Bronto. 
      That was very kind. The world needs more people like you, 
      *player*.
+     &exit
 
 bar_truebark4:
      I’ve been thinking of putting Ambrosia back on the menu one day 
      if The Cellist keeps up this streak of responsible consumption. 
      Perhaps in fifty years or so.
+     &exit
 
 bar_truebark5:
      I must say, I’ll miss you dearly when your path takes you away from 
      us. Should you visit, there will always be a seat for you at the 
      Bar Samsara.
+     &exit
 
 bar_truebark6:
      I saw The Pianist smile while helping at the Mewseum earlier. I 
      nearly dropped a bottle in shock. 
+     &exit
 
 
----
 
 piano_truebark1:
 
      Good to see you. How’s life as a freelancer treating ya? 
+     &exit
 
 piano_truebark2:
 
      Between you and me, I think this ‘going legit’ thing won’t last too  
      long. Give it a hundred years, and you’ll probably see us out on the
      Voidway again. 
+     &exit
 
 piano_truebark3:
 
      Hey, uh, have you seen The Singer? I got the guest beds set up in 
      the old study wing of the Mewseum as they asked. 
+     &exit
 
 piano_truebark4:
 
      Don’t tell him I said this, but it’s been nice hanging out with the 
      Cellist recently. Thanks for helping him out. It’s good to have my 
      friend back. 
+     &exit
 
 piano_truebark5:
 
      I managed another improvisation yesterday. I thought it was pretty 
      shit, but The Bartender loved it. It’s a start, right?
+     &exit
+
 
 piano_truebark6:
 
      What, hoping for some grand emotional gesture? Pfffft. C’mon. I will
      miss you when you leave, though.
+     &exit
 
----
+
 
 singer_truebark1:
      > The Singer is sitting with The Bartender, playing Go. They both greet 
      you fondly and you spend a while watching them play.
+     &exit
 
 singer_truebark2:
      > The Singer hugs you. You sit together and they tell you 
      about the help The Pianist and Cellist have been giving them at the
      Mewseum. They're very proud of both of them.
+     &exit
 
 singer_truebark3:
      > The Singer looks sad. They’ve been trying not to think about the 
      fact you’ll be leaving soon. But they thank you earnestly for the 
      happiness you’ve gifted them during your stay.
+     &exit
 
 singer_truebark4:
      > You see The Singer in the middle of a lesson plan in the Mewseum,
      reading to a gaggle of Combine soldiers. You smile at how hard they
      have to choke back tears of joy when one raises a hand to ask
      them a question.
+     &exit
 
 singer_truebark5:
      > The Singer waves! They show you the blueprints for a Mewseum 
      expansion. The Bar Samsara will also be expanding into 
      a hotel soon.
+     &exit
 
 singer_truebark6:
      > The Singer is taking a nap with Emily Bronto, who looks downright 
      fearsome with her new battle scars.
----
+     &exit
 
 cello_truebark1:
 
@@ -267,6 +439,7 @@ cello_truebark1:
      we’re so glad you could attend 
      and so on and so forth. 
      naw for real though it’s always good to see you
+     &exit
 
 cello_truebark2:
 
@@ -274,11 +447,13 @@ cello_truebark2:
      fifteen different layers of irony and/or hallucinogens in the way, 
      but...thanks for not giving up on me when i lost my grip. i don’t 
      think i’ll ever figure out the words that say what that meant to me.
+     &exit
 
 cello_truebark3:
 
      it’s been so long since The Pianist smiled this much that i forgot 
      how nice one looked on her. you did good by her, kid.
+     &exit
 
 cello_truebark4:
 
@@ -286,6 +461,7 @@ cello_truebark4:
      pipes. they’ve always had issues making friends that weren’t robots 
      cause they’re wired a little differently than most but you made them 
      feel as comfortable as we do. that ain’t common.
+     &exit
 
 cello_truebark5:
 
@@ -293,12 +469,14 @@ cello_truebark5:
      and let me tell you it’s an odd hour that goes by when i don’t want 
      to go back in time and punch myself for agreeing to that. i’m 
      noticing improvements in my health, though. begrudgingly.
+     &exit
 
 cello_truebark6:
 
      can I ask you a favor? if you see a metrocop with a little cat 
      emblem pin out there in the Void, tell them The Cellist says 
      hello...and that he’s sorry.
+     &exit
 
 
 

--- a/gamemodes/jazztronauts/gamemode/ui/dialog/cl_styling.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/dialog/cl_styling.lua
@@ -283,7 +283,7 @@ DialogCallbacks.Paint = function(_dialog)
 		surface.SetFont( "JazzDialogFontHint" )
 		local contstr = "Click to continue...	"
 		local tw,th = surface.GetTextSize(contstr)
-		local contX = x + w/2 - tw //* (localspeaker and 0.2 or 1)
+		local contX = x + w/2 - tw // * (localspeaker and 0.2 or 1)
 		if localspeaker then
 			contX = contX - ScreenScale(65)
 		end

--- a/gamemodes/jazztronauts/gamemode/ui/dialog/shared.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/dialog/shared.lua
@@ -92,6 +92,7 @@ local function ParseLine(script, line)
 		table.insert(script.tokens, {tok = tok, type = type}) tok = ""
 	end
 	local i = 1
+	
 	local inExec = false
 	repeat
 		local ch = line[i]


### PR DESCRIPTION
I spent so long getting this working, but now the idle.txt dialogue that's been sitting unused since Commit https://github.com/Foohy/jazztronauts/commit/d4dd9e14a8af33db32419cc14f11149a51ae1854 from 2018 will actually show up in-game.