### PR TITLE
Add setskin shortcut in setspeaker

### DIFF
--- a/gamemodes/jazztronauts/gamemode/ui/dialog/sh_dialogcmds.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/dialog/sh_dialogcmds.lua
@@ -237,7 +237,9 @@ dialog.RegisterFunc("show", function(d, time)
 	d.open = 1
 end)
 
-dialog.RegisterFunc("setspeaker", function(d, name)
+dialog.RegisterFunc("setspeaker", function(d, name, skinid)
+	skinid = skinid or nil
+	if skinid ~= nil then SetSkinFunc(d, name, skinid) end
 	dialog.SetFocusProxy(FindByName(name))
 end)
 
@@ -302,13 +304,17 @@ dialog.RegisterFunc("setanim", function(d, name, anim, speed, finishIdleAnim)
 end)
 
 dialog.RegisterFunc("setskin", function(d, name, skinid)
+	SetSkinFunc(d, name, skinid)
+end)
+-- Abstracted out for use in both setskin and setspeaker
+function SetSkinFunc(d, name, skinid)
 	local skinid = tonumber(skinid) or 0
 	local prop = FindByName(name)
 
 	if IsValid(prop) then
 		prop:SetSkin(skinid)
 	end
-end )
+end
 
 local view = {}
 dialog.RegisterFunc("setcam", function(d, ...)


### PR DESCRIPTION
A quick time-saving idea I had while tweaking the dialogue. It's pretty common to use `setskin` right after `setspeaker`. This allows you to optionally do both at the same time. So instead of doing `*setspeaker cat_singer* *setskin cat_singer 4*`, you can just do `*setspeaker cat_singer 4*`. Saves typing, keeps things visually cleaner, and will probably save a fuckton of bytes. I also have it change the skin *before* changing the speaker, to cut down on a bit of flickering.

If this is merged, I'll convert things to the new syntax as I go along with dialogue changes. Or if it's preferred, I can do it now and add it onto this PR.