### PR TITLE
Use actual name of required items in store

### DIFF
--- a/gamemodes/jazztronauts/gamemode/ui/store/store.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/store/store.lua
@@ -306,7 +306,7 @@ local function createListButton(parent, item)
 			self:SetEnabled(false)
 
 			if item.requires then
-				tooltip = tooltip.."\n"..jazzloc.Localize("jazz.store.requires",string.upper(item.requires))
+				tooltip = tooltip.."\n"..jazzloc.Localize("jazz.store.requires",string.upper(GetItem(item.requires).name))
 			end
 
 		-- Ready to buy


### PR DESCRIPTION
Pretty self explanatory, just gets the real name instead of showing the internal variable name. 

Side note: the new line causes this gap at the end of the tooltip, which I can't figure out why. I guess Gmod just renders newlines that way? It's so insignificant, who cares.

![tooltip showing a gap on the right side of it](https://github.com/Foohy/jazztronauts/assets/35016761/4ab16c9d-4de9-4e3c-a14a-46e252d8e5de)
