### PR TITLE
Add multiplayer conditional for dialogue (again)

### DIFF
--- a/gamemodes/jazztronauts/content/data/scripts_en/jazz_intro_2a.txt
+++ b/gamemodes/jazztronauts/content/data/scripts_en/jazz_intro_2a.txt
@@ -156,9 +156,18 @@ begin22:
 begin23:
 	*setspeaker cat_bar*
 	Ah.*setanim cat_bar gesture_clap 1 idle*% Would*setskin cat_bar 1* you look at what we have here? *setcam setpos -13669.89 -2033.84 1056.03;setang 2.67 81.38 0*
-	&begin24
+	condition:
+		&begin24multi:
+			return multiplayer()
+		&begin24single:
+			return true
 
-begin24:
+begin24single:
+	*setcam setpos -13689.892578 -2052.613770 1055.993286;setang 2.525014 -122.990868 0.000000*
+	A guest!
+	&begin25
+
+begin24multi:
 	*setcam setpos -13689.892578 -2052.613770 1055.993286;setang 2.525014 -122.990868 0.000000*
 	Guests!
 	&begin25

--- a/gamemodes/jazztronauts/content/data/scripts_en/jazz_intro_3a.txt
+++ b/gamemodes/jazztronauts/content/data/scripts_en/jazz_intro_3a.txt
@@ -26,10 +26,9 @@ begin2:
 	*hide*
 	*txout*
 	*setcam setpos -13086.006836 -2470.082764 1070.884399;setang 14.594378 -110.203735 0.000000*
-	*setspeaker cat_bar 1*
 	*txin*
 	*wait .15*
-	*show*
+	*show**setspeaker cat_bar 1*
 	Greetings.%%*setskin cat_bar 0* As you can see,% this place does*setanim cat_bar gesture_sweep 1 idle* not seem to have an exit.%%
 	While I'm sure you can leave through whatever way you came in,%%
 	we prefer a different method of travel.
@@ -73,7 +72,7 @@ m1:
 m2:
 	*hide*
 	*txout*
-	*setspeaker cat_bar*
+	*setspeaker narrator*
 	*setposang cat_bar setpos -13101.092773 -2689.411621 1025.5532715;setang -90 270 0.000000*
 	*setposang cat_cello setpos setpos -13140.460938 -2728.007324 1025.520874;setang -90 280 0.000000*
 	*setposang cat_piano setpos -13194.700195 -2656.432129 1025.534790;setang -90 175.826767 0.000000*
@@ -82,6 +81,23 @@ m2:
 	*txin*
 	*wait .15*
 	*show*
+	> You sit down in a surprisingly comfortable seat,
+	as the cats are preparing to start the trolley.
+	condition:
+		&m2multi:
+			return multiplayer()
+		&m2single:
+			return true
+
+m2multi:
+	*setspeaker cat_bar*
+	You'll want to fasten yourselves securely
+	in your seat,% and brace yourselves.%%
+	The first few trips through the Void can be*setskin cat_bar 4*%.%.%.% *setskin cat_bar 1*disorienting.
+	&m3
+
+m2single:
+	*setspeaker cat_bar*
 	You'll want to fasten yourself securely
 	in your seat,% and brace yourself.%%
 	The first few trips through the Void can be*setskin cat_bar 4*%.%.%.% *setskin cat_bar 1*disorienting.

--- a/gamemodes/jazztronauts/gamemode/ui/dialog/cl_dialog.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/dialog/cl_dialog.lua
@@ -231,6 +231,7 @@ local conditionEnv =
 	money = jazzmoney,
 	time = os.time,
 	date = os.date,
+	multiplayer = function() return tobool(player.GetCount() - 1) end,
 	maybe = function(odds, test) return math.Round(util.SharedRandom("shared", 1, odds, FrameNumber())) == test end
 }
 
@@ -324,7 +325,7 @@ function StartGraph(cmd, skipOpen, options, delay)
 		_dialog.nodeiter = buildIterator( cmd, ScriptCallback, EnterNode )
 	elseif t == "string" then
 
-		if IsScriptValid(cmd) then	
+		if IsScriptValid(cmd) then
 			_dialog.nodeiter = buildIterator( cmd, ScriptCallback, EnterGraph )
 			_dialog.entrypoint = cmd
 			_dialog.seen = false
@@ -339,7 +340,7 @@ function StartGraph(cmd, skipOpen, options, delay)
 				DialogQueued = true
 				hook.Add("JazzDialogReady", "JazzQueueDialog", function()
 					hook.Remove("JazzDialogReady", "JazzQueueDialog")
-					StartGraph(cmd, skipOpen, options, delay)	
+					StartGraph(cmd, skipOpen, options, delay)
 				end )
 			end
 
@@ -498,7 +499,7 @@ hook.Add("HUDPaint", "JazzDialogThrobber", function()
 
 	local nDots = math.floor(math.fmod(CurTime()*2, 3))
 	local str = "LOADING DIALOG"
-	
+
 	surface.SetFont("JazzDialogLoading")
 	local w, h = surface.GetTextSize(str)
 


### PR DESCRIPTION
Closes #98

Something went horribly, horribly wrong with #167 after it had merge conflicts. Let's try this again!

---

In reply to what was said in the other PR:

I figured it was gonna have merge conflicts, but that's fine, it gave me a chance to get around to improving the check and testing the new changes. And uh, good thing I did, because in 3a I accidentally added the `&` before the segment names, and the game softlocks after you get into the bus! So that's fixed now! :sweat: And even after fixing that, there's this really awkward delay from having a blank dialogue section... the best way I could think to fix that is just adding an extra narrator line. If that's all good, should be ready to merge!

@SageJFox You're right actually, since it would return -1 and be true... though I think there's bigger problems if there's somehow zero players :p I tried `return isbool(player.GetCount() - 1)`, but it seems to always return false. Gmod documentation says it purely checks whether or not a value is a boolean type. I think I found what you meant though, using `tobool` worked fine! I feel much happier with this PR now, knowing I'm not adding a whole stupid code block that's basically just "return true or false" xd

Also, the save data wasn't specifically about this, I just had built up a good testing save file, and having to wipe my save again to get to the prologue sucks. Plus, I never understood where it was, so I've always just lost my Gmod settings and Jazztronauts save whenever I switch computers or OSes... just a convenient time to ask so I don't keep having this problem!