### PR TITLE
Improve map scraper filter

### DIFF
--- a/other/scraper/scrape.py
+++ b/other/scraper/scrape.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import json
 import time
@@ -11,16 +13,24 @@ NUMPERPAGE = 100
 DELAY = 0.1 # How long to delay between requests
 FILENAME = "addons.txt"
 
-ignore_words = ["content", "server"]
+# Not a whole word search, so nav also gets navmesh
+ignore_words = [
+    "content",
+    "server",
+    "nav",
+    "node",
+    "icon"
+]
+
 ignore_reg = "(?<!_){0}(?!_)" # Allow ignore words to be a part of the map name (surrounding underscores)
 def containsIgnoreWord(str, word):
-    return re.search(ignore_reg.format(word), str) is not None
+    return re.search(ignore_reg.format(word), str, flags=re.IGNORECASE) is not None
 
 def containsIgnoreWords(str):
     for word in ignore_words:
         if containsIgnoreWord(str, word):
             return True
-        
+
     return False
 
 if __name__ == "__main__":
@@ -45,7 +55,9 @@ if __name__ == "__main__":
         total = resobj["response"]["total"]
 
         for addon in resobj["response"]["publishedfiledetails"]:
-            if "title" in addon and containsIgnoreWords(addon["title"]):
+            hasignorewords = "title" in addon and containsIgnoreWords(addon["title"])
+            sexyfuntimes = "maybe_inappropriate_sex" in addon and addon["maybe_inappropriate_sex"] == True
+            if hasignorewords or sexyfuntimes:
                 ign_str = u"Ignoring: " + addon["title"]
                 print(ign_str.encode('utf-8'))
                 continue
@@ -64,10 +76,10 @@ if __name__ == "__main__":
 
         if page * NUMPERPAGE > resobj["response"]["total"]:
             break
-        else:   
+        else:
             # so valve doesn't get angry at us
             time.sleep(DELAY)
-    
+
     # Results come back sorted, but reverse it so
     # newer entries are added at the end instead of shifting everything at the beginning
     workshopids.reverse()
@@ -78,4 +90,3 @@ if __name__ == "__main__":
 
     print("Finished!!")
     f.close()
-

--- a/other/scraper/scrape.py
+++ b/other/scraper/scrape.py
@@ -15,78 +15,78 @@ FILENAME = "addons.txt"
 
 # Not a whole word search, so nav also gets navmesh
 ignore_words = [
-    "content",
-    "server",
-    "nav",
-    "node",
-    "icon"
+	"content",
+	"server",
+	"nav",
+	"node",
+	"icon"
 ]
 
 ignore_reg = "(?<!_){0}(?!_)" # Allow ignore words to be a part of the map name (surrounding underscores)
 def containsIgnoreWord(str, word):
-    return re.search(ignore_reg.format(word), str, flags=re.IGNORECASE) is not None
+	return re.search(ignore_reg.format(word), str, flags=re.IGNORECASE) is not None
 
 def containsIgnoreWords(str):
-    for word in ignore_words:
-        if containsIgnoreWord(str, word):
-            return True
+	for word in ignore_words:
+		if containsIgnoreWord(str, word):
+			return True
 
-    return False
+	return False
 
 if __name__ == "__main__":
 
-    if len(sys.argv) <= 1:
-        print("A Steam WebAPI key is required.")
-        sys.exit(1)
+	if len(sys.argv) <= 1:
+		print("A Steam WebAPI key is required.")
+		sys.exit(1)
 
-    if len(sys.argv) > 2:
-        FILENAME = sys.argv[2]
+	if len(sys.argv) > 2:
+		FILENAME = sys.argv[2]
 
-    key = sys.argv[1]
-    page = 0
-    workshopids = []
+	key = sys.argv[1]
+	page = 0
+	workshopids = []
 
-    f = open(FILENAME, "w")
+	f = open(FILENAME, "w")
 
-    while True:
-        req = "{0}/{1}?key={2}&appid={3}&requiredtags[0]=map&numperpage={4}&page={5}&return_metadata=1&query_type=1".format(HOST, ENDPOINT, key, APPID, NUMPERPAGE, page)
-        response = urllib.request.urlopen(req).read()
-        resobj = json.loads(response.decode("utf-8", "ignore"))
-        total = resobj["response"]["total"]
+	while True:
+		req = "{0}/{1}?key={2}&appid={3}&requiredtags[0]=map&numperpage={4}&page={5}&return_metadata=1&query_type=1".format(HOST, ENDPOINT, key, APPID, NUMPERPAGE, page)
+		response = urllib.request.urlopen(req).read()
+		resobj = json.loads(response.decode("utf-8", "ignore"))
+		total = resobj["response"]["total"]
 
-        for addon in resobj["response"]["publishedfiledetails"]:
-            hasignorewords = "title" in addon and containsIgnoreWords(addon["title"])
-            sexyfuntimes = "maybe_inappropriate_sex" in addon and addon["maybe_inappropriate_sex"] == True
-            if hasignorewords or sexyfuntimes:
-                ign_str = u"Ignoring: " + addon["title"]
-                print(ign_str.encode('utf-8'))
-                continue
+		for addon in resobj["response"]["publishedfiledetails"]:
+			hasignorewords = "title" in addon and containsIgnoreWords(addon["title"])
+			sexyfuntimes = "maybe_inappropriate_sex" in addon and addon["maybe_inappropriate_sex"] == True
+			if hasignorewords or sexyfuntimes:
+				ign_str = u"Ignoring: " + addon["title"]
+				print(ign_str.encode('utf-8'))
+				continue
 
-            # Add if not already in (sometimes query will give us dupes?)
-            wsid = addon["publishedfileid"]
-            if not wsid in workshopids:
-                workshopids.append(wsid)
+			# Add if not already in (sometimes query will give us dupes?)
+			wsid = addon["publishedfileid"]
+			if not wsid in workshopids:
+				workshopids.append(wsid)
 
-        # Informative output
-        finished = page * NUMPERPAGE + len(resobj["response"]["publishedfiledetails"])
-        print("Finished {0} addons. ({1:.2f}% of {2})".format(finished, finished * 100.0 / total, total))
+		# Informative output
+		finished = page * NUMPERPAGE + len(resobj["response"]["publishedfiledetails"])
+		print("Finished {0} addons. ({1:.2f}% of {2})".format(finished, finished * 100.0 / total, total))
 
-        # Move onto to the next page
-        page += 1
+		# Move onto to the next page
+		page += 1
 
-        if page * NUMPERPAGE > resobj["response"]["total"]:
-            break
-        else:
-            # so valve doesn't get angry at us
-            time.sleep(DELAY)
+		if page * NUMPERPAGE > resobj["response"]["total"]:
+			break
+		else:
+			# so valve doesn't get angry at us
+			time.sleep(DELAY)
 
-    # Results come back sorted, but reverse it so
-    # newer entries are added at the end instead of shifting everything at the beginning
-    workshopids.reverse()
+	# Results come back sorted, but reverse it so
+	# newer entries are added at the end instead of shifting everything at the beginning
+	workshopids.reverse()
 
-    print("Dumping {0} addons to {1}".format(len(workshopids), FILENAME))
-    for id in workshopids:
-        f.write(id + "\n")
+	print("Dumping {0} addons to {1}".format(len(workshopids), FILENAME))
+	for id in workshopids:
+		f.write(id + "\n")
 
-    print("Finished!!")
-    f.close()
+	print("Finished!!")
+	f.close()


### PR DESCRIPTION
Closes #75

Added the phrases `nav`, `node`, and `icon`, to weed out all the navmesh and icon pack addons. Filter is now case-insensitive. Added an additional check for sexual content, to please stupid little 2019 me. Also added a shebang so the script is recognized as Python by shells. Also converted the script to tabs for consistency. Did the tabs in a separate commit so the diffs could be readable.