### PR TITLE
Remove sandbox TargetID

### DIFF
--- a/gamemodes/jazztronauts/gamemode/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/cl_init.lua
@@ -31,3 +31,7 @@ function GM:HUDShouldDraw( name )
 	end
 	return true
 end
+
+function GM:HUDDrawTargetID()
+	return false
+end


### PR DESCRIPTION
If you're looking at someone while dialogue starts (which is especially possible in the intro), the TargetID will follow your cursor the entire time, and it's quite unappealing.

Since it is redundant in Jazztronauts anyway, as everyone already has nametags at all times, and health is rarely if ever important, I think it's best to just remove it.