### PR TITLE
Adjust stock Sandbox hints

### DIFF
--- a/gamemodes/jazztronauts/gamemode/init.lua
+++ b/gamemodes/jazztronauts/gamemode/init.lua
@@ -429,6 +429,13 @@ function GM:PlayerInitialSpawn( ply )
 		end )
 	end
 
+	ply:SuppressHint( "Annoy1" )
+	ply:SuppressHint( "Annoy2" )
+	if mapcontrol.IsInGamemodeMap() then
+		ply:SuppressHint( "OpeningMenu" )
+	end
+	ply:SendHint( "OpeningContext", 30 )
+
 	-- Hey. Don't play this in singleplayer
 	if game.SinglePlayer() then
 		timer.Simple(5, function()

--- a/gamemodes/jazztronauts/gamemode/ui/spawnmenu/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/spawnmenu/cl_init.lua
@@ -8,7 +8,10 @@ function GM:SpawnMenuOpen()
 	if mapcontrol.IsInGamemodeMap() then return false end
 
 	GAMEMODE:SuppressHint( "OpeningMenu" )
-	GAMEMODE:AddHint( "OpeningContext", 20 )
 
 	return true
+end
+
+function GM:ContextMenuOpened()
+	GAMEMODE:SuppressHint( "OpeningContext" )
 end


### PR DESCRIPTION
A rather subjective change. Suppresses the "disable hints" hint that blasts you the second you spawn, it's quite annoying and throws a lot at you before you even understand it. Always shows a hint for the context menu if unopened in 30 seconds, to clarify that it's still available in Jazztronauts. Spawnmenu hint is kept and shown around the same time, for the same reason, but only when exploring. Otherwise, since there is no spawnmenu, it's suppressed.