### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report an problem with Jazztronauts
-labels: ["type: bug"]
+labels: ["bug"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report an problem with Jazztronauts
+labels: ["type: bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for creating a report! Please be sure to add a short and simple title above, with no tagging like [BUG].
+
+  - type: dropdown
+    id: addons
+    attributes:
+      label: How many addons were enabled when you tried this?
+      description: |
+        If you don't understand, please disable all your addons except Jazztronauts and test the problem again.
+        If doing that stops the problem, gradually enable addons until the issue reappears, then mention the last addon enabled later in the report.
+      options:
+        - I did not disable my addons before reporting this bug
+        - A specific addon(s) that causes the problem
+        - Nothing except Jazztronauts itself
+    validations:
+      required: true
+
+  - type: dropdown
+    id: system
+    attributes:
+      label: Which operating system were you using?
+      description: |
+        If you don't understand, pick Windows.
+        If you've tested multiple, pick the higher one on the list.
+        If you pick Linux, please state the distro and version later in the report.
+      options:
+        - Windows
+        - SteamOS / Steam Deck
+        - Linux
+        - macOS
+        - Something else
+    validations:
+      required: true
+
+  - type: dropdown
+    id: gmodversion
+    attributes:
+      label: Which branch of Garry's Mod were you on?
+      description: |
+        If you don't understand, pick Stable.
+        If you've tested multiple, pick the higher one on the list.
+      options:
+        - Stable
+        - x86-64 / Chromium
+        - prerelease
+        - dev
+    validations:
+      required: true
+
+  - type: dropdown
+    id: jazzversion
+    attributes:
+      label: What version of Jazztronauts were you running?
+      description: |
+        If you don't understand, pick Workshop addon.
+        If you've tested multiple, pick the higher one on the list.
+      options:
+        - Workshop addon
+        - Main/Master branch
+        - An unmerged branch
+    validations:
+      required: true
+
+  - type: textarea
+    id: whathappened
+    attributes:
+      label: What happened?
+      description: |
+        Please provide a clear and concise description of what the bug is.
+        You may want to give steps detailing how to make the problem appear.
+        Add any other context or screenshots that may be helpful.
+      placeholder: Say what you see!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -26,15 +26,17 @@ body:
     attributes:
       label: Which operating system were you using?
       description: |
-        If you don't understand, pick Windows.
+        If you don't understand, go to https://whatsmyos.com and look at the top.
         If you've tested multiple, pick the higher one on the list.
-        If you pick Linux, please state the distro and version later in the report.
+        If you're on a Steam Deck and switched Garry's Mod to run in Proton, select Linux through Proton.
+        If you choose Linux, state the distro and version later in the report.
       options:
         - Windows
-        - SteamOS / Steam Deck
+        - Linux through Proton
+        - SteamOS (Steam Deck) # yes i know steamos is linux, but this lets us target steam deck specific compatibility
         - Linux
         - macOS
-        - Something else
+        - Something else (specify later)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,20 @@
+name: Feature request
+description: Suggest an addition to Jazztronauts
+labels: ["type: enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for making a request! Please be sure to add a short and simple title above, with no tagging like [FEATURE].
+
+  - type: textarea
+    id: whathappened
+    attributes:
+      label: What's your request?
+      description: |
+        Please provide a clear and concise description of what you want to happen.
+        If it's related to another issue, you should mention that.
+        Add any other context or screenshots that may be helpful.
+      placeholder: Say what you want to see!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an addition to Jazztronauts
-labels: ["type: enhancement"]
+labels: ["enhancement"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/something_else.yaml
+++ b/.github/ISSUE_TEMPLATE/something_else.yaml
@@ -1,0 +1,15 @@
+name: Something else
+description: Anything else you might wanna say about Jazztronauts
+
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for making an issue! Please be sure to add a short and simple title above, with no tagging like [QUESTION].
+
+  - type: textarea
+    id: whathappened
+    attributes:
+      label: What would you like to say?
+      placeholder: Say what you want to say!
+    validations:
+      required: true


### PR DESCRIPTION
This is a relatively new feature of GitHub which massively reduces issues with insufficient information. Rather than hoping users provide helpful information, or using the classic issue template system which was plain text that could simply be deleted, this presents the questions in a real form with proper UI elements.

Here, I've added 3 templates. All of them end with a standard text area which can be filled out the exact same way as a traditional issue. They also discourage title tagging, like [BUG] or [FEATURE], since the issues are automatically tagged.

1. Bug reports, the most thorough template, which asks for detailed information about the user's setup and possible variables for reproducing the bug. It also assigns the issue the bug tag automatically.
2. Feature requests, much simpler and closer to just leaving a traditional issue, but it also adds the enhancement tag automatically.
3. Essentially just a traditional issue. The reason for this is that normally, GitHub shows the blank issue button like a footnote, away from all the big buttons for templates. I personally believe it's cleaner UX to disable that footnote and have another template consistent with the others. 

You can [read about this feature here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), and you can tinker with the system on [my fork where it's activated](https://github.com/Commenter25/jazztronauts/issues/new/choose), and you can see an [example issue made with this system](https://github.com/Commenter25/jazztronauts/issues/3).

(note, the templates on my fork i linked above is now slightly out of date since it's only the first commit, but you can still get a feel for it)