### PR TITLE
Scale Bartender chat menu with distance

### DIFF
--- a/gamemodes/jazztronauts/entities/entities/jazz_cat/cl_init.lua
+++ b/gamemodes/jazztronauts/entities/entities/jazz_cat/cl_init.lua
@@ -51,8 +51,8 @@ function ENT:OnMouseReleased(ply, key)
 end
 
 function ENT:ShouldDrawChat()
-	local pos = self:GetMenuPosAng(LocalPlayer())
-	return LocalPlayer():EyePos():Distance(pos) < self.ChatFadeDistance
+	local _,_,dist = self:GetMenuPosAng(LocalPlayer())
+	return dist < self.ChatFadeDistance
 end
 
 function ENT:UpdateChatFade()

--- a/gamemodes/jazztronauts/entities/entities/jazz_cat/cl_init.lua
+++ b/gamemodes/jazztronauts/entities/entities/jazz_cat/cl_init.lua
@@ -52,7 +52,7 @@ end
 
 function ENT:ShouldDrawChat()
 	local _,_,dist = self:GetMenuPosAng(LocalPlayer())
-	return dist < self.ChatFadeDistance
+	return (dist < self.ChatFadeDistance) and !dialog.IsInDialog()
 end
 
 function ENT:UpdateChatFade()


### PR DESCRIPTION
No more crouching on top of the bar like an insane person.

This dynamically scales the menu based on distance, even moving it up and down to ensure it looks just right. To compensate, the distance check was slightly reworked to not include the vertical offset. I kept it working with `flipChat`, even though I doubt that'll ever be used at this point. Also, the menu hides when in dialogue, to avoid a weird edge case where it renders in the chatbox view. Can't use it in there anyway.

<details>

<summary>Comparison images (4MB)</summary>

Apologies for the awful quality, I do my development on a craptop... but the low resolution also highlights how unreadable the small size can be.

**Before:**
![Standing in front of the Bartender before this PR](https://github.com/Foohy/jazztronauts/assets/35016761/5236e8dd-b977-4599-83e0-27f8c8811f16)
![Standing at the edge of the bar before this PR](https://github.com/Foohy/jazztronauts/assets/35016761/c1b782b5-f760-4bc5-b534-2d28952796de)

**After:**
![Standing in front of the Bartender after this PR](https://github.com/Foohy/jazztronauts/assets/35016761/e1a85421-ca7b-46e2-9df4-05316c6f35bc)
![Standing at the edge of the bar after this PR](https://github.com/Foohy/jazztronauts/assets/35016761/32c530f2-c80e-4a5b-9171-0022adc39364)

</details>