### PR TITLE
Add Player vs Player toggle

### DIFF
--- a/gamemodes/jazztronauts/gamemode/init.lua
+++ b/gamemodes/jazztronauts/gamemode/init.lua
@@ -461,9 +461,13 @@ function GM:IsSpawnpointSuitable(ply, spawnent, makesuitable)
 	return true
 end
 
--- Don't allow pvp damage
+-- Don't allow pvp by default, except self-damage cause rocketjumping fun
 function GM:PlayerShouldTakeDamage(ply, attacker)
-	return not (attacker:IsValid() and attacker:IsPlayer())
+	if attacker:IsValid() and attacker:IsPlayer() and ply != attacker then
+		return cvars.Bool("jazz_player_pvp")
+	end
+
+	return true
 end
 
 -- no fall damange with Run

--- a/gamemodes/jazztronauts/gamemode/player/player_hub.lua
+++ b/gamemodes/jazztronauts/gamemode/player/player_hub.lua
@@ -67,25 +67,16 @@ if CLIENT then
 	end )
 end
 
-
-local convarCollide = CreateConVar("jazz_player_collide", "0", { FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY },
-	"Toggles players colliding with each other. Default is 0. Should be enabled when jazz_player_pvp enabled, or hitscan weapons won't function.")
-cvars.AddChangeCallback("jazz_player_collide", function(_, old, new)
-	if tobool(new) == false and cvars.Bool("jazz_player_pvp") then
-		print("WARNING: Disabling jazz_player_collide will break jazz_player_pvp, as hitscan weapons won't function!")
-	end
-end )
-
 -- Turns out TeammateNoCollide is really funky. Zombies can't attack you (among other oddities)
 -- So just manually check collision here for players
 hook.Add("ShouldCollide", "JazzPlayerCollide", function(ent1, ent2)
 	if not (ent1:IsPlayer() and ent2:IsPlayer()) then return end
-	if convarCollide:GetBool() then return end
+	if cvars.Bool("jazz_player_pvp") then return end
 	return false
 end )
 
--- Called from JazzPlayerSpawnLogic
--- By now we're certain ply1 is really a player, and player_collide is on
+-- Called from JazzPlayerSpawnLogic and player_pvp callback
+-- By now we're certain ply1 is really a player, and player collision is on
 hook.Add("JazzPlayerOnPlayer", "JazzPlayerCollideUnstuck", function(ply1, spawn)
 	local function checkPlayer()
 		local pos = ply1:GetPos()
@@ -103,7 +94,7 @@ hook.Add("JazzPlayerOnPlayer", "JazzPlayerCollideUnstuck", function(ply1, spawn)
 
 	-- determine who we could be stuck on
 	local ply2 = false
-	if spawn:IsPlayer() then ply2 = spawn end
+	if IsValid(spawn) and spawn:IsPlayer() then ply2 = spawn end
 	-- it's possible they didn't spawn *on* a player, but one happened to be standing there
 	if !ply2 then
 		local initTrace = checkPlayer()

--- a/gamemodes/jazztronauts/gamemode/player/sh_spectate.lua
+++ b/gamemodes/jazztronauts/gamemode/player/sh_spectate.lua
@@ -45,6 +45,13 @@ if SERVER then
 		-- Sit em' down
 		if IsValid(bus) then
 			bus:SitPlayer(ply)
+			return
+		end
+
+		-- Activate anti-stuck code when players are allowed to collide
+		-- Prob doesn't need to be a hook, but makes sense keeping it with the other collision stuff
+		if cvars.Bool("jazz_player_collide") then
+			hook.Run("JazzPlayerOnPlayer", ply, ent)
 		end
 	end )
 

--- a/gamemodes/jazztronauts/gamemode/player/sh_spectate.lua
+++ b/gamemodes/jazztronauts/gamemode/player/sh_spectate.lua
@@ -48,9 +48,9 @@ if SERVER then
 			return
 		end
 
-		-- Activate anti-stuck code when players are allowed to collide
+		-- Activate anti-stuck code when PvP is on since players are allowed to collide
 		-- Prob doesn't need to be a hook, but makes sense keeping it with the other collision stuff
-		if cvars.Bool("jazz_player_collide") then
+		if cvars.Bool("jazz_player_pvp") then
 			hook.Run("JazzPlayerOnPlayer", ply, ent)
 		end
 	end )

--- a/gamemodes/jazztronauts/gamemode/shared.lua
+++ b/gamemodes/jazztronauts/gamemode/shared.lua
@@ -11,10 +11,13 @@ team.SetUp( 1, "Jazztronauts", Color( 255, 128, 0, 255 ) )
 
 -- Defined here for users to see, functionality is in init.lua
 CreateConVar("jazz_player_pvp", "0", { FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY },
-	"Allow players to damage each other. Default is 0. When enabled, also enables jazz_player_collide, as hitscan weapons won't function otherwise.")
+	"Allow players to damage each other. Default is 0. When enabled, players will collide, as hitscan weapons won't function otherwise.")
+
 cvars.AddChangeCallback("jazz_player_pvp", function(_, old, new)
 	if tobool(new) == true then
-		GetConVar("jazz_player_collide"):SetBool(true)
+		for i, ply in ipairs( player.GetAll() ) do
+			hook.Run("JazzPlayerOnPlayer", ply)
+		end
 	end
 end )
 

--- a/gamemodes/jazztronauts/gamemode/shared.lua
+++ b/gamemodes/jazztronauts/gamemode/shared.lua
@@ -9,6 +9,14 @@ GM.Website = "https://steamcommunity.com/sharedfiles/filedetails/?id=1452613192"
 
 team.SetUp( 1, "Jazztronauts", Color( 255, 128, 0, 255 ) )
 
+-- Defined here for users to see, functionality is in init.lua
+CreateConVar("jazz_player_pvp", "0", { FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY },
+	"Allow players to damage each other. Default is 0. When enabled, also enables jazz_player_collide, as hitscan weapons won't function otherwise.")
+cvars.AddChangeCallback("jazz_player_pvp", function(_, old, new)
+	if tobool(new) == true then
+		GetConVar("jazz_player_collide"):SetBool(true)
+	end
+end )
 
 CreateConVar("jazz_override_noclip", "1", { FCVAR_REPLICATED, FCVAR_NOTIFY }, "Allow jazztronauts to override when players can noclip. If 0, it is determined by sandbox + whatever other mods you've got.")
 
@@ -146,26 +154,26 @@ else
 
 		if dmg == DMG_FALL then
 
-			ev:Title(jazzloc.Localize("jazz.death.fall","%name"), 
+			ev:Title(jazzloc.Localize("jazz.death.fall","%name"),
 				{ name = name }
 			)
 
 		elseif attacker == ply then
 
-			ev:Title(jazzloc.Localize("jazz.death.self","%name"), 
+			ev:Title(jazzloc.Localize("jazz.death.self","%name"),
 				{ name = name }
 			)
 
 		elseif IsValid(attacker) then
 
-			ev:Title(jazzloc.Localize("jazz.death.killer","%name","%killer"), 
+			ev:Title(jazzloc.Localize("jazz.death.killer","%name","%killer"),
 				{ name = name, killer = attacker:GetClass() },
 				{ killer = "red_name" }
 			)
 
 		else
 
-			ev:Title(jazzloc.Localize("jazz.death.generic","%name"), 
+			ev:Title(jazzloc.Localize("jazz.death.generic","%name"),
 				{ name = name }
 			)
 

--- a/gamemodes/jazztronauts/jazztronauts.txt
+++ b/gamemodes/jazztronauts/jazztronauts.txt
@@ -26,5 +26,14 @@
 			"type"		"CheckBox"
 			"default"	"0"
 		}
+
+		3
+		{
+			"name"		"jazz_player_pvp"
+			"text"		"players_damage_players"
+			"help"		"#jazz.gamemode.pvp.help"
+			"type"		"CheckBox"
+			"default"	"0"
+		}
 	}
 }

--- a/resource/localization/en/jazztronauts.properties
+++ b/resource/localization/en/jazztronauts.properties
@@ -170,6 +170,8 @@ jazz.gamemode.wait=Wait for players at the start of a level
 jazz.gamemode.wait.help=Whether or not to enable the waiting for players whiteboard at all
 jazz.gamemode.localaddons=Include local addons in map randomizer
 jazz.gamemode.localaddons.help=If enabled, maps from locally installed workshop addons will be included when rolling for a map
+# pvp name provided by sandbox
+jazz.gamemode.pvp.help=If enabled, players will collide and be able to hurt each other
 #==============================================================================
 #	LEVEL SELECT MULTI-LANGUAGE (no need to add these to other files!) --TODO: just running these through google translate for testing purposes. Need to make sure they're proper translations!
 #==============================================================================


### PR DESCRIPTION
This adds a new convar, `jazz_player_pvp`. When this is enabled, players will also collide, because otherwise hitscan weapons such as bullets and melee no longer function.

For collision to work properly, I had to add a system to get players unstuck if they spawn on each other. After spawning, it will check within your bounding box for another player. If one is found, you'll be allowed to pass through each other until you're no longer in contact, then the system deactivates and collision is normal.

I felt this would be of significant enough interest to add to the main menu, so it's an option there as well. Regardless of PvP, I also allowed self-damage at all times while I was here, since the only instance I can think of is explosive jumping, which is just fun.

---

This PR originally added another convar, `jazz_player_collide`, to allow toggling collisions separately. However, PvP relies on collision being on, and it's hard to consistently automatically toggle it without annoying the user. Particularly, seemingly due to Facepunch/garrysmod-issues#1440, toggling PvP in the menu won't run `AddChangeCallback`, so it can't enable collisions as well. It's a rather niche bit of customization anyway, so I've axed the extra convar and it's now just PvP.