### PR TITLE
Fix Camera SWEP

### DIFF
--- a/gamemodes/jazztronauts/entities/weapons/weapon_hacker.lua
+++ b/gamemodes/jazztronauts/entities/weapons/weapon_hacker.lua
@@ -79,7 +79,7 @@ function SWEP:Initialize()
 		table.Add(self.GlitchSources,ents.FindByClass("phys_magnet"))
 		]]
 	else
-		
+
 	end
 end
 
@@ -90,6 +90,7 @@ function SWEP:ShouldDrawHackerview()
 		return
 	end
 
+	if jazzHideHUD then return 0 end
 	if owner != LocalPlayer() or owner:GetActiveWeapon() != self then return 0 end
 	if !unlocks.IsUnlocked("store", owner, upgrade_enableWrites) then return 1 end
 	return 2 //Turbo
@@ -145,7 +146,7 @@ function SWEP:CalcGlitch()
 		local viewmodel = self.Owner:GetViewModel()
 
 		if IsValid(viewmodel) then
-			
+
 			local maxrange = 640000 --800^2 (HL2 geiger counter starts going off at 800HU)
 			local pos = self.Owner:GetPos()
 			self.GlitchIdeal = 0.0 --reset ideal glitchiness
@@ -190,7 +191,7 @@ end
 
 function SWEP:CanPrimaryAttack()
 
-	return unlocks.IsUnlocked("store", self:GetOwner(), upgrade_enableWrites) 
+	return unlocks.IsUnlocked("store", self:GetOwner(), upgrade_enableWrites)
 
 end
 

--- a/gamemodes/jazztronauts/entities/weapons/weapon_propsnatcher/shared.lua
+++ b/gamemodes/jazztronauts/entities/weapons/weapon_propsnatcher/shared.lua
@@ -519,7 +519,7 @@ SWEP.EquipFade = 0
 function SWEP:DrawHUD()
 	local owner = self:GetOwner()
 	if not IsValid(owner) or IsValid(owner:GetVehicle()) then return end -- Don't draw while in vehicle
-	if dialog.IsInDialog() then return end -- Also don't draw while in a dialog
+	if jazzHideHUD or dialog.IsInDialog() then return end -- Also don't draw while in a dialog
 
 	local pfov = LocalPlayer():GetFOV()
 	local aimradius = (ScrW() / 2) * math.tan(math.rad(90 - pfov/2)) * math.tan(math.rad(self.AutoAimCone))

--- a/gamemodes/jazztronauts/gamemode/cl_hud.lua
+++ b/gamemodes/jazztronauts/gamemode/cl_hud.lua
@@ -168,9 +168,6 @@ local function DrawNoteCount()
 end
 
 local function DrawBlackShardCount()
-	if mapcontrol.IsInGamemodeMap() then return end
-	if GAMEMODE:IsWaitingForPlayers() then return end
-
 	local bshard = IsValid(bshard) and bshard or ents.FindByClass("jazz_shard_black")[1]
 	if not IsValid(bshard) or not bshard.GetStartSuckTime then return end
 
@@ -190,9 +187,6 @@ local function DrawBlackShardCount()
 end
 
 local function DrawShardCount()
-	if mapcontrol.IsInGamemodeMap() then return end
-	if GAMEMODE:IsWaitingForPlayers() then return end
-
 	local left, total = mapgen.GetShardCount()
 	local str = jazzloc.Localize("jazz.shards.partialcollected",total - left,total)
 	local color = Color(143, 0, 255, 100)
@@ -205,12 +199,14 @@ local function DrawShardCount()
 	local offset = surface.GetTextSize(str) / 2
 	offset = offset + 5
 	draw.WordBox( 5, ScrW() / 2 - offset, 5, str, "JazzNote", color, color_white )
-
 end
 
 hook.Add("HUDPaint", "JazzDrawHUD", function()
-	if !GetConVar("cl_drawhud"):GetBool() then return end
+	if jazzHideHUD then return end
+
 	DrawNoteCount()
+
+	if mapcontrol.IsInGamemodeMap() then return end
 
 	local isCommitted = mapgen.GetTotalCollectedBlackShards() > mapgen.GetTotalRequiredBlackShards() / 2
 	if isCommitted then
@@ -219,18 +215,18 @@ hook.Add("HUDPaint", "JazzDrawHUD", function()
 		DrawShardCount()
 	end
 
-	-- Always show the moneybux in the hub
-	if mapcontrol.IsInHub() then
-		HideTime = math.huge
-	end
-
 end )
+
+-- Always show the moneybux in the hub, skip the scoreboard stuff below
+if mapcontrol.IsInHub() then
+	HideTime = math.huge
+	return
+end
 
 //Show the money count when pressing tab
 hook.Add( "ScoreboardShow", "jazz_scoreboardShow", function()
 	HideTime = math.huge
 end )
 hook.Add("ScoreboardHide", "jazz_scoreboardHide", function()
-	if mapcontrol.IsInHub() then return end
 	HideTime = CurTime()
 end )

--- a/gamemodes/jazztronauts/gamemode/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/cl_init.lua
@@ -15,19 +15,33 @@ include( "cl_jazzphysgun.lua")
 include( "cl_texturelocs.lua" )
 include( "cl_hud.lua" )
 
-GM.HideHUD = {
-	"CHudHealth",
-	"CHudBattery",
-	"CHudAmmo",
-	"CHudSecondaryAmmo",
-	"CHudCrosshair",
+local shouldHide = {
+	["CHudHealth"] = true,
+	["CHudBattery"] = true,
+	["CHudAmmo"] = true,
+	["CHudSecondaryAmmo"] = true,
+	["CHudCrosshair"] = true,
 }
 
 local isInSpecialMap = mapcontrol.IsInHub() or mapcontrol.IsInEncounter()
 
+jazzHideHUD = false
+hook.Add( "PreDrawHUD", "JazzCheckToHideHUD", function()
+	local playerwep = LocalPlayer():GetActiveWeapon()
+
+	if (IsValid(playerwep) and playerwep:GetClass() == "gmod_camera")
+	or !GetConVar("cl_drawhud"):GetBool()
+	or GAMEMODE:IsWaitingForPlayers() then
+		jazzHideHUD = true
+	else
+		jazzHideHUD = false
+	end
+end )
+
 function GM:HUDShouldDraw( name )
 	if isInSpecialMap or dialog.IsInDialog() then
-		return !table.HasValue(self.HideHUD, name)
+		if shouldHide[name] then return false end
 	end
-	return true
+
+	return self.BaseClass.HUDShouldDraw(self, name)
 end

--- a/gamemodes/jazztronauts/gamemode/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/cl_init.lua
@@ -26,6 +26,7 @@ local shouldHide = {
 local isInSpecialMap = mapcontrol.IsInHub() or mapcontrol.IsInEncounter()
 
 jazzHideHUD = false
+jazzHideHUDSpecial = false
 hook.Add( "PreDrawHUD", "JazzCheckToHideHUD", function()
 	local playerwep = LocalPlayer():GetActiveWeapon()
 
@@ -36,10 +37,16 @@ hook.Add( "PreDrawHUD", "JazzCheckToHideHUD", function()
 	else
 		jazzHideHUD = false
 	end
+
+	if isInSpecialMap or dialog.IsInDialog() then
+		jazzHideHUDSpecial = true
+	else
+		jazzHideHUDSpecial = false
+	end
 end )
 
 function GM:HUDShouldDraw( name )
-	if isInSpecialMap or dialog.IsInDialog() then
+	if jazzHideHUDSpecial then
 		if shouldHide[name] then return false end
 	end
 

--- a/gamemodes/jazztronauts/gamemode/ui/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/cl_init.lua
@@ -13,6 +13,8 @@ function GM:HUDPaint()
 
 	self.BaseClass.HUDPaint(self)
 
+	if jazzHideHUD then return end
+
 	dialog.PaintAll()
 	--radar.Paint()
 	propfeed.Paint()
@@ -23,7 +25,7 @@ function GM:HUDPaint()
 end
 
 hook.Add("Think", "JazzTickDialog", function()
-	
+
 	dialog.Update( FrameTime() )
 
 end )

--- a/gamemodes/jazztronauts/gamemode/ui/missions/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/missions/cl_init.lua
@@ -133,7 +133,7 @@ end
 
 local ShowFinishedMissions = false
 hook.Add("HUDPaint", "JazzDrawMissions", function()
-	if !GetConVar("cl_drawhud"):GetBool() then return end
+	if jazzHideHUD then return end
 	
 	local spacing = ScreenScale(2)
 	local offset = ScreenScale(40)


### PR DESCRIPTION
Should be a bit more optimized as well, since all the "should i be drawn" checks are centralized into one global variable set before everything else. Dialog and special maps should still stay separate.

Also used a less complex table method for HUDShouldDraw.