### PR TITLE
Revamped mission list

### DIFF
--- a/gamemodes/jazztronauts/gamemode/missions/missions.lua
+++ b/gamemodes/jazztronauts/gamemode/missions/missions.lua
@@ -371,25 +371,35 @@ elseif CLIENT then
 			prog[mid] = num
 		end
 
-		-- Build a mission history table that matches what sql would give us
+		-- Build a mission history table that matches what sql would give us, separate tables for ui
 		ClientMissionHistory = {}
+		local CompletedList = {}
+		local ActiveList = {}
 		for k, v in SortedPairs(MissionList) do
 			local completed = hist[k] != nil
 			local active = prog[k] != nil
 
 			if not completed and not active then continue end
 
-			ClientMissionHistory[k] =
-			{
+			local missiontable = {
 				missionid = k,
 				completed = completed,
 				progress = prog[k] or v.Count
 			}
+
+			if completed then
+				table.insert(CompletedList, missiontable)
+			else
+				table.insert(ActiveList, missiontable)
+			end
+
+			ClientMissionHistory[k] = missiontable
 		end
 
 		Active = prog
 		Finished = hist
 
-		hook.Call("JazzMissionsUpdated", GAMEMODE, hist, prog)
+		hook.Run("JazzMissionsUpdated", hist, prog)
+		hook.Run("JazzMissionsUpdateUI", ActiveList, CompletedList)
 	end )
 end

--- a/gamemodes/jazztronauts/gamemode/ui/dialog/cl_dialog.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/dialog/cl_dialog.lua
@@ -438,6 +438,12 @@ function IsInDialog()
 	return _dialog.nodeiter != nil
 end
 
+-- 0 is not open, 1 is fully open, decimals for transitioning between
+-- Use this to make things do smooth animations during dialog open and close
+function GetOpen()
+	return _dialog.open
+end
+
 function GetParam(name)
 	if not _dialog.curCmd or not _dialog.curCmd.env or not _dialog.curCmd.env.params then return nil end
 	return _dialog.curCmd.env.params[name]

--- a/gamemodes/jazztronauts/gamemode/ui/dialog/cl_dialog.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/dialog/cl_dialog.lua
@@ -438,12 +438,6 @@ function IsInDialog()
 	return _dialog.nodeiter != nil
 end
 
--- 0 is not open, 1 is fully open, decimals for transitioning between
--- Use this to make things do smooth animations during dialog open and close
-function GetOpen()
-	return _dialog.open
-end
-
 function GetParam(name)
 	if not _dialog.curCmd or not _dialog.curCmd.env or not _dialog.curCmd.env.params then return nil end
 	return _dialog.curCmd.env.params[name]

--- a/gamemodes/jazztronauts/gamemode/ui/missions/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/ui/missions/cl_init.lua
@@ -118,7 +118,7 @@ end)
 
 local ShowFinishedMissions = false
 hook.Add("HUDPaint", "JazzDrawMissions", function()
-	if !GetConVar("cl_drawhud"):GetBool() then return end
+	if jazzHideHUD then return end
 
 	local dialogopen = dialog.GetOpen()
 	if dialogopen == 1 then return end


### PR DESCRIPTION
I tweaked the mission list UI to scale properly to different resolutions, while also fitting the longest mission title.

Also, for consistency, finished missions always appear above active ones.

Also also, the list smoothly slides out for dialog, and back in after.

<details>

<summary>Comparison images (1MB)</summary>

The images are a little hard to compare due to how much changes between them, but I tried to make it as consistent as possible. I took two sets, one at 720p and one at 1080p. I've tested this at various other resolutions as well.

**Before:**
![The mission list in 720p before this PR](https://github.com/Foohy/jazztronauts/assets/35016761/c73b394c-5355-4be0-a3a0-e920305a5c33)
![The mission list in 1080p before this PR](https://github.com/Foohy/jazztronauts/assets/35016761/3ac1255b-b134-432d-9057-45a216a9d2d9)

**After:**
![The mission list in 720p after this PR](https://github.com/Foohy/jazztronauts/assets/35016761/862e7853-3f54-4c15-817c-df94a345f812)
![The mission list in 1080p after this PR](https://github.com/Foohy/jazztronauts/assets/35016761/883816ce-226f-496e-a72f-5b7cc6048a22)

</details>