### PR TITLE
Fade money counter when in dialog

### DIFF
--- a/gamemodes/jazztronauts/gamemode/cl_init.lua
+++ b/gamemodes/jazztronauts/gamemode/cl_init.lua
@@ -38,7 +38,7 @@ hook.Add( "PreDrawHUD", "JazzCheckToHideHUD", function()
 		jazzHideHUD = false
 	end
 
-	if isInSpecialMap or dialog.IsInDialog() then
+	if isInSpecialMap or dialog.IsInDialog() or jazzHideHUD then
 		jazzHideHUDSpecial = true
 	else
 		jazzHideHUDSpecial = false


### PR DESCRIPTION
When entering dialog, it smoothly fades out. When leaving dialog, smoothly fades back in. If your amount changes mid-dialog (when you complete a mission), it'll appear for that then fade again. Made the coin properly fade too so it looks nicer. 

Also fixed the money hiding in the hub when the amount changes.

Also made jazzHideHUD also trigger Special, primarily just for the waiting for players screen.