### PR TITLE
no ajar doors/windows counting for the chems mission (hopefully?)

### DIFF
--- a/gamemodes/jazztronauts/gamemode/missions/missionlist.lua
+++ b/gamemodes/jazztronauts/gamemode/missions/missionlist.lua
@@ -173,7 +173,8 @@ AddMission(2, NPC_CAT_CELLO, {
 				"models/props/de_train/biohazardtank.mdl",
 				"models/props/de_train/biohazardtank_dm_10.mdl"
 			}) or
-			string.match(mdl, "jar") or
+			(string.match(mdl, "jar") and
+				not (string.match(mdl, "_ajar")) or
 			(string.match(mdl, "bottle") and
 				(string.match(mdl, "plastic") or
 				 string.match(mdl, "flask") or


### PR DESCRIPTION
minor nitpick i noticed while browsing through the gmod spawnmenu; ajar doors and windows technically could count for the chems mission. this PR fixes that, hopefully.